### PR TITLE
Fix build workflow target SDK

### DIFF
--- a/.github/workflows/build_deb.yml
+++ b/.github/workflows/build_deb.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up THEOS (with submodules) + SDK links
         env:
           # Change this if your Makefile TARGET ends with another min iOS
-          MIN_IOS: "9.2"
+          MIN_IOS: "16.1"
         run: |
           # Theos + submodules (dm.pl etc.)
           git clone --depth=1 --recurse-submodules https://github.com/theos/theos.git "$HOME/theos"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 FINALPACKAGE = 1
 
-export TARGET = iphone:17.0.2:15.0
+# Build with the latest available SDK while targeting iOS 16.1 (16.1.2 compatible)
+export TARGET = iphone:clang:latest:16.1
 export ADDITIONAL_CFLAGS = -DTHEOS_LEAN_AND_MEAN -fobjc-arc -O3
 
 ARCHS = arm64 arm64e


### PR DESCRIPTION
## Summary
- target the build at iOS 16.1 so the library remains compatible with iOS 16.1.2
- align the build workflow's SDK symlink setup with the new minimum iOS version

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68db098faac483218ad3e29a34420dfe